### PR TITLE
fix: create separate test file, which will be deleted later

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -3,6 +3,7 @@ from src.paste.main import app
 
 client = TestClient(app)
 
+file = None 
 
 def test_get_health_route():
     data = {"status": "ok"}
@@ -38,12 +39,14 @@ def test_post_web_route():
     data = 'This is a test data'
     form_data = {'content': data}
     response = client.post("/web", data=form_data)
+    global file
+    file = str(response.url).split("/")[-1]
     assert response.status_code == 200
     assert response.text == data
 
 
 def test_delete_paste_route():
-    expected_response = "File successfully deleted test"
-    response = client.delete("/paste/test")
+    expected_response = f"File successfully deleted {file}"
+    response = client.delete(f"/paste/{file}")
     assert response.status_code == 200
     assert response.text == expected_response

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -3,7 +3,8 @@ from src.paste.main import app
 
 client = TestClient(app)
 
-file = None 
+file = None
+
 
 def test_get_health_route():
     data = {"status": "ok"}
@@ -50,3 +51,35 @@ def test_delete_paste_route():
     response = client.delete(f"/paste/{file}")
     assert response.status_code == 200
     assert response.text == expected_response
+
+
+def test_post_file_route():
+    response = client.post(
+        "/file", files={"file": ("test.txt", b"test file content")})
+    assert response.status_code == 201
+    response_file_uuid = response.text
+    response = client.get(f"/paste/{response_file_uuid}")
+    assert response.status_code == 200
+    assert response.text == "test file content"
+    response = client.delete(f"/paste/{response_file_uuid}")
+    assert response.status_code == 200
+    assert response.text == f"File successfully deleted {response_file_uuid}"
+
+
+def test_post_file_route_failure():
+    response = client.post("/file")
+    assert response.status_code == 422  # Unprocessable Entity
+    assert response.json() == {
+        "detail": [
+            {
+                "type": "missing",
+                "loc": [
+                    "body",
+                    "file"
+                ],
+                "msg": "Field required",
+                "input": None,
+                "url": "https://errors.pydantic.dev/2.5/v/missing"
+            }
+        ]
+    }


### PR DESCRIPTION
Addressed in #26 
Improvement: added a global variable `file`, which will be updated by response of `test_post_web_route()` and deleted by `test_delete_paste_route()`.